### PR TITLE
Fix typo in RestClientBindings.java

### DIFF
--- a/hadoop-swiftfs/src/main/java/org/apache/hadoop/fs/swift/http/RestClientBindings.java
+++ b/hadoop-swiftfs/src/main/java/org/apache/hadoop/fs/swift/http/RestClientBindings.java
@@ -42,7 +42,7 @@ public final class RestClientBindings {
   private static final Log LOG = LogFactory.getLog(RestClientBindings.class);
 
   public static final String E_INVALID_NAME = "Invalid swift hostname '%s':" +
-          " hostname must in form container.service";
+          " hostname must inform container.service";
 
   /**
    * Public for testing : build the full prefix for use in resolving


### PR DESCRIPTION
Changed "in form" to "inform".
